### PR TITLE
Fix: Importing a session now loads Locus associated with session

### DIFF
--- a/packages/ui/src/components/Igv/ExportIGV.tsx
+++ b/packages/ui/src/components/Igv/ExportIGV.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { useAtom } from "jotai";
-import { IGVBrowserHandle } from "./IGVBrowser";
+import IGVBrowser, { IGVBrowserHandle } from "./IGVBrowser";
 import { BGZip } from "igv-utils";
 
 const exclusionFn = (track: any) => {
@@ -68,6 +68,7 @@ const ExportIGVSession: React.FC<{
   };
 
   const importSessionFromJSON = (session: any) => {
+    igvBrowserRef.current?.getBrowser()?.search(session.locus);
     const importedTracks = [];
     for (const track of session.tracks) {
       if (exclusionFn(track)) {

--- a/packages/ui/src/components/Igv/ExportIGV.tsx
+++ b/packages/ui/src/components/Igv/ExportIGV.tsx
@@ -68,7 +68,6 @@ const ExportIGVSession: React.FC<{
   };
 
   const importSessionFromJSON = (session: any) => {
-    igvBrowserRef.current?.getBrowser()?.search(session.locus);
     const importedTracks = [];
     for (const track of session.tracks) {
       if (exclusionFn(track)) {
@@ -90,6 +89,11 @@ const ExportIGVSession: React.FC<{
     // Restore ROIs if they exist in the session
     if (session.roi && igvBrowserRef.current) {
       igvBrowserRef.current.setROI(session.roi);
+    }
+    
+    // Restore the Locus Session Data (Locus should always be present)
+    if (session.locus && igvBrowserRef.current) {
+      igvBrowserRef.current.setLocus(session.locus);
     }
   };
 


### PR DESCRIPTION
<img width="1316" height="609" alt="Screenshot 2025-07-16 at 2 27 54 PM" src="https://github.com/user-attachments/assets/3d150fa0-3410-4b0e-847f-4348ec50334d" />
Importing a saved session will now load the locus information associated with the session data. 
Targets issue #3 