### PR TITLE
[Fix]: Fixes table refresh on update

### DIFF
--- a/packages/ui/src/components/Igv/DataTrackTable.tsx
+++ b/packages/ui/src/components/Igv/DataTrackTable.tsx
@@ -21,14 +21,6 @@ type DataTableProps = {
 const DataTrackTable: React.FC<DataTableProps> = ({ loading, error, data, filenameStem, igvTracksSetAtom }) => {
   const [tracksSet, setTracksSet] = useAtom(igvTracksSetAtom);
 
-  console.log("akdsfjlkdjflakdf");
-  console.log(tracksSet);
-  const getTrackSet = () => {
-    console.log("hijijiojoi");
-    console.log(tracksSet);
-    return tracksSet;
-  };
-
   // Add all tracks for the specific cellTypeId/study combination
   const addAllTracksForRow = (study: string, cellTypeId: string) => {
     setTracksSet(prevTrackSet => {

--- a/packages/ui/src/components/OtTable/OtTable.tsx
+++ b/packages/ui/src/components/OtTable/OtTable.tsx
@@ -123,6 +123,7 @@ function OtTable({
   const table = useReactTable({
     data: tableData,
     columns: tableColumns,
+    autoResetPageIndex: false,
     filterFns: {
       searchFilterFn: searchFilter,
     },


### PR DESCRIPTION
Fixes #6 
[Fix]: Prevents Data Table (OtTable) from refreshing on a table update (e.g. adding a track). Works across all data tables that uses OtTable. 
<img width="1694" height="757" alt="image" src="https://github.com/user-attachments/assets/3c5a1ca1-267e-4a6c-9a71-313ea2d69428" />
Image Caption: Example of adding a track on the Variants Page, but it stays on the current page index regardless of update.