### PR TITLE
fix(egp): export gene symbol & biosample name in TSV/CSV/JSON, not [o…

### DIFF
--- a/packages/sections/src/variant/EnhancerToGenePredictions/Body.tsx
+++ b/packages/sections/src/variant/EnhancerToGenePredictions/Body.tsx
@@ -34,6 +34,8 @@ const columns = [
     },
     filterValue: ({ target }: { target: Target }) =>
       target?.approvedSymbol || "",
+    exportValue: ({ target }: { target: Target }) =>
+      target?.approvedSymbol || "",
   },
   {
     id: "biosample",
@@ -54,6 +56,8 @@ const columns = [
     },
     filterValue: ({ biosample }: { biosample: Biosample }) =>
       biosample?.biosampleFromSource || biosample?.biosampleId || "",
+    exportValue: ({ biosample }: { biosample: Biosample }) =>
+      biosample?.biosampleName || biosample?.biosampleId || "",
   },
   {
     id: "intervalType",


### PR DESCRIPTION
…bject Object]

The Enhancer-to-Gene predictions table's 'target' and 'biosample' columns hold objects and had renderCell but no exportValue. DataDownloader falls back to _.get(row, column.id) when exportValue is absent, so the raw object was serialized as '[object Object]' in downloads. Add exportValue to both: target -> approvedSymbol, biosample -> biosampleName (|| biosampleId).

Fixes #13 